### PR TITLE
Add AWS xray configuration

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,9 @@ from flask import request
 from flask.logging import default_handler
 
 from asim_formatter import ASIMFormatter
+from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
+
 from config import get_ipfilter_config
 from utils import constant_time_is_equal
 
@@ -22,6 +25,9 @@ HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
 app = Flask(__name__, template_folder=Path(__file__).parent, static_folder=None)
 app.config.from_object("settings")
 
+if app.config["ENABLE_XRAY"]:
+    xray_recorder.configure(service="ipfilter")
+    XRayMiddleware(app, xray_recorder)
 
 PoolClass = (
     urllib3.HTTPConnectionPool
@@ -34,6 +40,7 @@ default_handler.setFormatter(ASIMFormatter())
 logging.basicConfig(stream=sys.stdout, level=app.config["LOG_LEVEL"])
 logger = logging.getLogger(__name__)
 logger.addHandler(default_handler)
+
 request_id_alphabet = string.ascii_letters + string.digits
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -3,4 +3,5 @@ gunicorn
 urllib3
 jinja2
 pyyaml
+aws-xray-sdk>=2.12.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,12 @@
 #
 #    pip-compile
 #
+aws-xray-sdk==2.12.1
+    # via -r requirements.in
 blinker==1.6.2
     # via flask
+botocore==1.34.1
+    # via aws-xray-sdk
 click==8.1.7
     # via flask
 flask==2.3.2
@@ -18,16 +22,26 @@ jinja2==3.1.2
     # via
     #   -r requirements.in
     #   flask
+jmespath==1.0.1
+    # via botocore
 markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
+python-dateutil==2.8.2
+    # via botocore
 pyyaml==6.0.1
     # via -r requirements.in
+six==1.16.0
+    # via python-dateutil
 urllib3==1.26.18
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   botocore
 werkzeug==3.0.1
     # via flask
+wrapt==1.16.0
+    # via aws-xray-sdk
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/settings.py
+++ b/settings.py
@@ -41,3 +41,5 @@ PUBLIC_PATHS = env.list("PUBLIC_PATHS", default=[], allow_environment_override=T
 PROTECTED_PATHS = env.list(
     "PROTECTED_PATHS", default=[], allow_environment_override=True
 )
+
+ENABLE_XRAY = env.bool("ENABLE_XRAY", default=False)


### PR DESCRIPTION
Initial x-ray config as per 

https://docs.aws.amazon.com/xray-sdk-for-python/latest/reference/frameworks.html

This is currently not tested - we'll need to deploy it to an env to test it out.  Also x-ray is disabled by default.   We probably want to create an associated PR on the copilot-deploy repo to add the following config into the service manifest template:

```
observability:
    xray
````


