### PR TITLE
Fix ip-filter repo

### DIFF
--- a/.copilot/config.yml
+++ b/.copilot/config.yml
@@ -1,4 +1,4 @@
-repository: public.ecr.aws/uktrade/ci-image-builder
+repository: public.ecr.aws/uktrade/ip-filter
 builder:
   name: paketobuildpacks/builder-jammy-base
   version: 0.4.240


### PR DESCRIPTION
This should be pointed at ip-filter, not ci-image-builder.