### PR TITLE
feat: DBTP-816 IP Filter needs to allow unblocked access from other tasks

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,9 +133,13 @@ def handle_request(u_path):
             logger.error(f"[%s] {ex}", request_id)
             return render_access_denied(client_ip, forwarded_url, request_id, str(ex))
 
-        ip_in_whitelist = any(
-            ip_address(client_ip) in ip_network(ip_range)
-            for ip_range in ip_filter_rules["ips"]
+        additional_ip_list = app.config["ADDITIONAL_IP_LIST"]
+        ip_in_whitelist = (
+            any(
+                ip_address(client_ip) in ip_network(ip_range)
+                for ip_range in ip_filter_rules["ips"]
+            )
+            or client_ip in additional_ip_list
         )
 
         shared_tokens = ip_filter_rules["shared_tokens"]

--- a/settings.py
+++ b/settings.py
@@ -41,3 +41,6 @@ PUBLIC_PATHS = env.list("PUBLIC_PATHS", default=[], allow_environment_override=T
 PROTECTED_PATHS = env.list(
     "PROTECTED_PATHS", default=[], allow_environment_override=True
 )
+ADDITIONAL_IP_LIST = env.list(
+    "ADDITIONAL_IP_LIST", default=[], allow_environment_override=True
+)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -315,20 +315,16 @@ class ConfigurationTestCase(unittest.TestCase):
         self.assertEqual(response.status, 200)
 
     def test_ipfilter_enabled_allow_additional_ip_addresses(self):
-        self.addCleanup(create_appconfig_agent(2772))
-
-        wait_until_connectable(2772)
-
         self._setup_environment(
             (
                 ("COPILOT_ENVIRONMENT_NAME", "staging"),
                 ("IPFILTER_ENABLED", "True"),
-                ("APPCONFIG_PROFILES", "testapp:testenv:testconfig"),
-                ("ADDITIONAL_IP_LIST", "1.2.3.10"),
+                ("ADDITIONAL_IP_LIST", "1.3.2.4, 1.3.2.5"),
+                ("PUBLIC_PATHS", "/public-test"),
             )
         )
-        response = self._make_request()
 
+        response = self._make_request("/protected-test")
         self.assertEqual(response.status, 200)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -314,6 +314,23 @@ class ConfigurationTestCase(unittest.TestCase):
 
         self.assertEqual(response.status, 200)
 
+    def test_ipfilter_enabled_allow_additional_ip_addresses(self):
+        self.addCleanup(create_appconfig_agent(2772))
+
+        wait_until_connectable(2772)
+
+        self._setup_environment(
+            (
+                ("COPILOT_ENVIRONMENT_NAME", "staging"),
+                ("IPFILTER_ENABLED", "True"),
+                ("APPCONFIG_PROFILES", "testapp:testenv:testconfig"),
+                ("ADDITIONAL_IP_LIST", "1.2.3.10"),
+            )
+        )
+        response = self._make_request()
+
+        self.assertEqual(response.status, 200)
+
 
 class ProxyTestCase(unittest.TestCase):
     """Tests that cover the ip filter's proxy functionality."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -319,7 +319,7 @@ class ConfigurationTestCase(unittest.TestCase):
             (
                 ("COPILOT_ENVIRONMENT_NAME", "staging"),
                 ("IPFILTER_ENABLED", "True"),
-                ("ADDITIONAL_IP_LIST", "1.3.2.4, 1.3.2.5"),
+                ("ADDITIONAL_IP_LIST", "1.1.1.1"),
                 ("PUBLIC_PATHS", "/public-test"),
             )
         )


### PR DESCRIPTION
The idea would be to allow a list of additiona IP addresses to be let through. The list should be specified as an env override like so:

```
environments:
  dev:
    http:
      alias: the.service.alias
    sidecars:
      nginx:
        image: path/to/the/image/:latest
        variables:
          PRIV_PATH_LIST: '/admin'
      ipfilter:
        variables:
          PUBLIC_PATHS: ""
          IP_DETERMINED_BY_X_FORWARDED_FOR_INDEX: -3
        secrets:
          ADDITIONAL_IP_LIST: /copilot/app_name/env_name/secrets/ADDITIONAL_IP_LIST
```

`ADDITIONAL_IP_LIST` comes from SSM and should contain the list of IP addresses that can be added to the whitelist