### PR TITLE
Enable sentry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.11
 
-MAINTAINER tools@digital.trade.gov.uk
-
 RUN apt-get update && apt-get install -qq build-essential \
                                           libpq-dev \
                                           python3-dev \
@@ -12,11 +10,10 @@ RUN apt-get update && apt-get install -qq build-essential \
 
 WORKDIR /app
 
+COPY pyproject.toml /app
+RUN pip install poetry && poetry add honcho && poetry install
+
+
 COPY . /app
 
-RUN pip install -r /app/requirements.txt
-
-RUN pip install honcho
-
-CMD honcho start
-
+CMD ["poetry", "run", "honcho", "start"]

--- a/asim_formatter.py
+++ b/asim_formatter.py
@@ -63,7 +63,7 @@ class ASIMFormatter(logging.Formatter):
             "HttpContentFormat": request.mimetype,
             "HttpReferrer": request.referrer,
             "HttpUserAgent": str(request.user_agent),
-            "HttpRequestXff": request.headers["X-Forwarded-For"],
+            "HttpRequestXff": request.headers.get("X-Forwarded-For"),
             "HttpResponseTime": "N/A",
             "HttpHost": request.host,
             # TODO: add better support for multi-file upload and other file fields e.g. FileSize

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,23 @@
 services:
+  nginx:
+    image: public.ecr.aws/uktrade/nginx-reverse-proxy:latest
+    ports:
+      - "9999:443"
+    environment:
+      SERVER: ipfilter:8000
   ipfilter:
     build: .
     ports:
       - "8000:8000"
     environment:
       PORT: 8000
-      COPILOT_ENVIRONMENT: staging
+      COPILOT_APPLICATION_NAME: localtest
+      COPILOT_ENVIRONMENT_NAME: dev
       EMAIL_NAME: 'The Department for International Trade WebOps team'
       EMAIL: test@test.test
-      LOG_LEVEL: DEBUG
-      ORIGIN_HOSTNAME: localhost:8080
-      ORIGIN_PROTO: http
+      LOG_LEVEL: INFO
+      SERVER: app:8080
+      #SENTRY_DSN: https://.... 
   app:
     image: nginx:latest
     ports:

--- a/settings.py
+++ b/settings.py
@@ -6,7 +6,7 @@ from config import Environ
 
 env = Environ(os.environ)
 
-LOG_LEVEL = env.get("LOG_LEVEL", "WARN")
+LOG_LEVEL = env.get("LOG_LEVEL", "INFO")
 
 logging.basicConfig(stream=sys.stdout, level=LOG_LEVEL)
 logger = logging.getLogger(__name__)
@@ -56,3 +56,4 @@ if ENABLE_XRAY:
 ADDITIONAL_IP_LIST = env.list(
     "ADDITIONAL_IP_LIST", default=[], allow_environment_override=True
 )
+


### PR DESCRIPTION
Add sentry to the IP Filter.  

Sentry is enabled if the `SENTRY_DSN` environment variable is activated.
We're using a single sentry project called `ip-filter` with a separate environment for each application/environment
The default log level has been bumped from `warn` to `info` so that we get some log output by default.

