### PR TITLE
DBTP-921 Allow IP filter to filter based on host header

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -41,6 +41,8 @@ PUBLIC_PATHS = env.list("PUBLIC_PATHS", default=[], allow_environment_override=T
 PROTECTED_PATHS = env.list(
     "PROTECTED_PATHS", default=[], allow_environment_override=True
 )
+PUB_HOST_LIST = env.list("PUB_HOST_LIST", default=[], allow_environment_override=True)
+PRIV_HOST_LIST = env.list("PRIV_HOST_LIST", default=[], allow_environment_override=True)
 
 ENABLE_XRAY = env.bool("ENABLE_XRAY", default=False)
 
@@ -56,4 +58,3 @@ if ENABLE_XRAY:
 ADDITIONAL_IP_LIST = env.list(
     "ADDITIONAL_IP_LIST", default=[], allow_environment_override=True
 )
-

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -327,6 +327,74 @@ class ConfigurationTestCase(unittest.TestCase):
         response = self._make_request("/protected-test")
         self.assertEqual(response.status, 200)
 
+    def test_pub_host_preferred_when_pub_and_priv(self):
+        self._setup_environment(
+            (
+                ("COPILOT_ENVIRONMENT_NAME", "staging"),
+                ("IPFILTER_ENABLED", "True"),
+                ("PUB_HOST_LIST", "127.0.0.1:8080"),
+                ("PRIV_HOST_LIST", "127.0.0.1:8080"),
+            )
+        )
+
+        response = self._make_request()
+
+        self.assertEqual(response.status, 200)
+
+    def test_host_in_pub_host_list(self):
+        self._setup_environment(
+            (
+                ("COPILOT_ENVIRONMENT_NAME", "staging"),
+                ("IPFILTER_ENABLED", "True"),
+                ("PUB_HOST_LIST", "127.0.0.1:8080"),
+            )
+        )
+
+        response = self._make_request()
+
+        self.assertEqual(response.status, 200)
+
+    def test_host_in_priv_host_list(self):
+        self._setup_environment(
+            (
+                ("COPILOT_ENVIRONMENT_NAME", "staging"),
+                ("IPFILTER_ENABLED", "True"),
+                ("PRIV_HOST_LIST", "127.0.0.1:8081"),
+            )
+        )
+
+        response = self._make_request()
+
+        self.assertEqual(response.status, 200)
+
+    def test_pub_host_list_and_protected_path(self):
+        self._setup_environment(
+            (
+                ("COPILOT_ENVIRONMENT_NAME", "staging"),
+                ("IPFILTER_ENABLED", "True"),
+                ("PUB_HOST_LIST", "127.0.0.1:8080"),
+                ("PROTECTED_PATHS", "/admin"),
+            )
+        )
+
+        response = self._make_request("/admin")
+
+        self.assertEqual(response.status, 403)
+
+    def test_priv_host_list_and_public_path(self):
+        self._setup_environment(
+            (
+                ("COPILOT_ENVIRONMENT_NAME", "staging"),
+                ("IPFILTER_ENABLED", "True"),
+                ("PRIV_HOST_LIST", "127.0.0.1:8080"),
+                ("PUBLIC_PATHS", "/"),
+            )
+        )
+
+        response = self._make_request()
+
+        self.assertEqual(response.status, 403)
+
 
 class ProxyTestCase(unittest.TestCase):
     """Tests that cover the ip filter's proxy functionality."""


### PR DESCRIPTION
Adds mutually exclusive `PUB_HOSTS_LIST` and `PRIV_HOSTS_LIST` settings and updates logic for enabling ip filter based on combination of these and `PUBLIC_PATHS` / `PRIVATE_PATHS`