### PR TITLE
DBTP-973 Restore ASIM logging for IP filter

### DIFF
--- a/asim_formatter.py
+++ b/asim_formatter.py
@@ -17,14 +17,6 @@ class ASIMFormatter(logging.Formatter):
 
         return event_result
 
-    def _get_file_name(self, request: Request) -> str:
-        if not request.files:
-            return "N/A"
-        if len(request.files.keys()) == 1:
-            return request.files.keys()[0]
-
-        return ";".join(request.files.keys()[0])
-
     def _get_event_severity(self, log_level: str) -> str:
         map = {
             "DEBUG": "Informational",
@@ -70,11 +62,6 @@ class ASIMFormatter(logging.Formatter):
                 "TraceHeaders": {},
             },
         }
-
-        content_type = request.headers.get("Content-Type")
-        if content_type and content_type == "multipart/form-data":
-            # TODO: add better support for multi-file upload and other file fields e.g. FileSize
-            request_dict["Filename"] = self._get_file_name(request)
 
         for trace_header in os.environ.get("DLFA_TRACE_HEADERS", ("X-Amzn-Trace-Id",)):
             request_dict["AdditionalFields"]["TraceHeaders"][

--- a/asim_formatter.py
+++ b/asim_formatter.py
@@ -17,6 +17,14 @@ class ASIMFormatter(logging.Formatter):
 
         return event_result
 
+    def _get_file_name(self, response: Response) -> str:
+        content_disposition = response.headers.get("Content-Disposition")
+
+        if content_disposition:
+            return content_disposition.split("filename=")[-1].strip('"')
+
+        return "N/A"
+
     def _get_event_severity(self, log_level: str) -> str:
         map = {
             "DEBUG": "Informational",
@@ -74,6 +82,7 @@ class ASIMFormatter(logging.Formatter):
         return {
             "EventResult": self._get_event_result(response),
             "EventResultDetails": response.status_code,
+            "FileName": self._get_file_name(response),
             "HttpStatusCode": response.status_code,
         }
 

--- a/asim_formatter.py
+++ b/asim_formatter.py
@@ -66,12 +66,15 @@ class ASIMFormatter(logging.Formatter):
             "HttpRequestXff": request.headers.get("X-Forwarded-For"),
             "HttpResponseTime": "N/A",
             "HttpHost": request.host,
-            # TODO: add better support for multi-file upload and other file fields e.g. FileSize
-            "FileName": self._get_file_name(request),
             "AdditionalFields": {
                 "TraceHeaders": {},
             },
         }
+
+        content_type = request.headers.get("Content-Type")
+        if content_type and content_type == "multipart/form-data":
+            # TODO: add better support for multi-file upload and other file fields e.g. FileSize
+            request_dict["Filename"] = self._get_file_name(request)
 
         for trace_header in os.environ.get("DLFA_TRACE_HEADERS", ("X-Amzn-Trace-Id",)):
             request_dict["AdditionalFields"]["TraceHeaders"][

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from flask.logging import default_handler
 from flask_caching import Cache
 from sentry_sdk.integrations.flask import FlaskIntegration
 
+from asim_formatter import ASIMFormatter
 from config import ValidationError
 from config import get_ipfilter_config
 from utils import constant_time_is_equal
@@ -55,7 +56,9 @@ PoolClass = (
 http = PoolClass(app.config["SERVER"], maxsize=10)
 
 logging.basicConfig(stream=sys.stdout, level=app.config["LOG_LEVEL"])
+default_handler.setFormatter(ASIMFormatter())
 logger = logging.getLogger(__name__)
+logger.addHandler(default_handler)
 request_id_alphabet = string.ascii_letters + string.digits
 
 urllib3_log_level = logging.getLevelName(os.getenv("URLLIB3_LOG_LEVEL", "WARN"))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2247,7 +2247,6 @@ class LoggingTestCase(unittest.TestCase):
                 "HttpRequestXff": request.headers["X-Forwarded-For"],
                 "HttpResponseTime": "N/A",
                 "HttpHost": request.host,
-                "FileName": "N/A",
                 "AdditionalFields": {
                     "TraceHeaders": {"X-Amzn-Trace-Id": "123testid"},
                 },
@@ -2319,7 +2318,6 @@ class LoggingTestCase(unittest.TestCase):
                     "HttpRequestXff": request.headers["X-Forwarded-For"],
                     "HttpResponseTime": "N/A",
                     "HttpHost": request.host,
-                    "FileName": "N/A",
                     "AdditionalFields": {
                         "TraceHeaders": {"X-Amzn-Trace-Id": None},
                     },

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2255,7 +2255,10 @@ class LoggingTestCase(unittest.TestCase):
     def test_asim_formatter_get_response_dict(self):
         response = Response(
             status=200,
-            headers={"Content-Type": "application/json"},
+            headers={
+                "Content-Type": "application/json",
+                "Content-Disposition": "attachment; filename=dummy.rtf",
+            },
             response='{"key": "value"}',
         )
 
@@ -2264,6 +2267,7 @@ class LoggingTestCase(unittest.TestCase):
         assert response_dict == {
             "EventResult": "Success",
             "EventResultDetails": response.status_code,
+            "FileName": "dummy.rtf",
             "HttpStatusCode": response.status_code,
         }
 
@@ -2323,6 +2327,7 @@ class LoggingTestCase(unittest.TestCase):
                     },
                     "EventResult": "Success",
                     "EventResultDetails": response.status_code,
+                    "FileName": "N/A",
                     "HttpStatusCode": response.status_code,
                 }
             )


### PR DESCRIPTION
I can't work out exactly why but playing with `request.files` in Flask seems to be the source of the timeout issue here. I think this is because the `Content-Type` header doesn't match what would be expected for a file upload POST request 

https://flask.palletsprojects.com/en/3.0.x/patterns/fileuploads/

This fixes the ICMS issue we were seeing, but I still need to test it against file upload POST 