### PR TITLE
chore: change IP_DETERMINED_BY_X_FORWARDED_FOR_INDEX default from -1 to -2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following are settings that apply globally.
 | `LOG_LEVEL` | The Python log level | `INFO`
 | `URLLIB3_LOG_LEVEL` | The log level for the urllib3 library | `WARN`
 | `PORT` | The port for the application to listen on | `8080`
-| `IP_DETERMINED_BY_X_FORWARDED_FOR_INDEX` | The index of the client IP in the XFF header, defaults to -1 | -1
+| `IP_DETERMINED_BY_X_FORWARDED_FOR_INDEX` | The index of the client IP in the XFF header, defaults to -2 | -2
 | `APPCONFIG_URL` | The URL of the local AppConfig agent | http://localhost:2772
 
 The following settings can be applied globally and overridden on a per environment basis.

--- a/settings.py
+++ b/settings.py
@@ -26,7 +26,7 @@ EMAIL_NAME = env.get("EMAIL_NAME", "DBT")
 EMAIL = env["EMAIL"]
 
 IP_DETERMINED_BY_X_FORWARDED_FOR_INDEX = env.int(
-    "IP_DETERMINED_BY_X_FORWARDED_FOR_INDEX", default=-1
+    "IP_DETERMINED_BY_X_FORWARDED_FOR_INDEX", default=-2
 )
 
 # These settings can be overridden per environment, e.g. if $COPILOT_ENVIRONMENT is set to "staging", then


### PR DESCRIPTION
We just copied over the old default from the other app, but this sidecar is only used in copilot world and the default we need there is -2. We never need -1 and only change to -3 when using CDN endpoint