### PR TITLE
fix: DPM-325 - allow networks in ADDITIONAL_IP_LIST

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,6 +190,10 @@ def handle_request(u_path):
                 for ip_range in ip_filter_rules["ips"]
             )
             or client_ip in additional_ip_list
+            or any(
+                ip_address(client_ip) in ip_network(ip_range)
+                for ip_range in additional_ip_list
+            )
         )
 
         shared_tokens = ip_filter_rules["shared_tokens"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -327,6 +327,19 @@ class ConfigurationTestCase(unittest.TestCase):
         response = self._make_request("/protected-test")
         self.assertEqual(response.status, 200)
 
+    def test_ipfilter_enabled_allow_additional_ip_networks(self):
+        self._setup_environment(
+            (
+                ("COPILOT_ENVIRONMENT_NAME", "staging"),
+                ("IPFILTER_ENABLED", "True"),
+                ("ADDITIONAL_IP_LIST", "1.1.1.0/29"),
+                ("PUBLIC_PATHS", "/public-test"),
+            )
+        )
+
+        response = self._make_request("/protected-test")
+        self.assertEqual(response.status, 200)
+
     def test_pub_host_preferred_when_pub_and_priv(self):
         self._setup_environment(
             (


### PR DESCRIPTION
Problem: Tariffs API needs to add a set of network addresses, like `1.1.1.0/29` to the additional ip list for their api. IP filter doesn't support this currently and uses a simple `client_ip in additional_ip_list` check.

Solution: Add a check for `client_ip`'s presence within an ip network using the same approach as used against app config ips. 