### PR TITLE
chore: Don't set new releases as a draft

### DIFF
--- a/release-config.json
+++ b/release-config.json
@@ -4,7 +4,7 @@
     ".": {
         "release-type": "python",
         "include-v-in-tag": false,
-        "draft": true,
+        "draft": false,
         "pull-request-header": ":robot: Next release",
         "pull-request-footer": " "
     }


### PR DESCRIPTION
Using draft mode confuses the release action and it can't work out what the latest release was.