### PR TITLE
ci: DBTP-1552 Exclude test files from Codecov checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
 codecov:
   notify:
     after_n_builds: 2
+
+ignore:
+  - "conftest.py"
+  - "test_*.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,5 +3,4 @@ codecov:
     after_n_builds: 2
 
 ignore:
-  - "conftest.py"
-  - "test_*.py"
+  - "**/tests/**"


### PR DESCRIPTION
Can be seen in action at https://app.codecov.io/github/uktrade/ip-filter/tree/DBTP-1552-exclude-test-files-from-codecov-2, but we may need to erase the existing data to get risd of the metrics which include the test files. Time will tell.