### PR TITLE
ci: disable package mode to fix error when installing test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "2.0.2"
 description = ""
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
This sets `package-mode = false` in pyproject.toml.

This is to avoid this error that happens when running `poetry install`:

> Warning: The current project could not be installed: No file/folder found for package ip-filter
> If you do not want to install the current project use --no-root.
> If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
> If you did intend to install the current project, you may need to set `packages` in your pyproject.toml file.

I see poetry 2.0.0 was released a few days ago, and from some quick tests on the earlier version, it showed a similar message, but also said:

> In a future version of Poetry this warning will become an error!

So I suspect the recent release is the reason why this suddenly broke (and the version of poetry itself is not pinned).