### PR TITLE
feat(logging): Add fields to enable Datadog logs correlation (DBTP-1662)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn main:app --worker-class gevent -b 0.0.0.0:$PORT
+web: ddtrace-run gunicorn main:app --worker-class gevent -b 0.0.0.0:$PORT

--- a/asim_formatter.py
+++ b/asim_formatter.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime
 
 import ddtrace
-from ddtrace import tracer
+from ddtrace.trace import tracer
 from flask import Request
 from flask import Response
 from flask import has_request_context

--- a/asim_formatter.py
+++ b/asim_formatter.py
@@ -27,12 +27,18 @@ class ASIMFormatter(logging.Formatter):
         except (KeyError, IndexError):
             return ""
 
+    def _get_first_64_bits_of(self, trace_id: int):
+        # See https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/python/#no-standard-library-logging
+        return str((1 << 64) - 1 & trace_id)
+
     def _datadog_trace_dict(self):
         event_dict = {}
 
         span = tracer.current_span()
         trace_id, span_id = (
-            (str((1 << 64) - 1 & span.trace_id), span.span_id) if span else (None, None)
+            (self._get_first_64_bits_of(span.trace_id), span.span_id)
+            if span
+            else (None, None)
         )
 
         # add ids to structlog event dictionary

--- a/asim_formatter.py
+++ b/asim_formatter.py
@@ -14,6 +14,19 @@ from utils import get_package_version
 
 
 class ASIMFormatter(logging.Formatter):
+    def _get_container_id(self):
+        """
+        The dockerId (container Id) is available via the metadata endpoint. However, the it looks like it is embedded in the
+        metadata URL,eg:
+        ECS_CONTAINER_METADATA_URI=http://169.254.170.2/v3/709d1c10779d47b2a84db9eef2ebd041-0265927825
+        See: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4-response.html
+        """
+
+        try:
+            return os.environ["ECS_CONTAINER_METADATA_URI"].split("/")[-1]
+        except (KeyError, IndexError):
+            return ""
+
     def _datadog_trace_dict(self):
         event_dict = {}
 
@@ -30,6 +43,8 @@ class ASIMFormatter(logging.Formatter):
         event_dict["env"] = ddtrace.config.env or ""
         event_dict["service"] = ddtrace.config.service or ""
         event_dict["version"] = ddtrace.config.version or ""
+
+        event_dict["container_id"] = self._get_container_id()
 
         return event_dict
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2128,7 +2128,7 @@ files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
-markers = {dev = "python_version < \"3.12\""}
+markers = {dev = "python_version ~= \"3.11.0\""}
 
 [[package]]
 name = "tzdata"
@@ -2412,4 +2412,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "911290bb99a717c68cc9c1cbb044099979ad29113dc4f4eb71ac239357138d20"
+content-hash = "b92da30bbee11381acbee9a17d2a20f6d8622302d58fec10fec6c8a0ad8c4d04"

--- a/poetry.lock
+++ b/poetry.lock
@@ -71,6 +71,18 @@ files = [
 ]
 
 [[package]]
+name = "bytecode"
+version = "0.16.1"
+description = "Python module to generate and modify bytecode"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "bytecode-0.16.1-py3-none-any.whl", hash = "sha256:1d4b61ed6bade4bff44127c8283bef8131a664ce4dbe09d64a88caf329939f35"},
+    {file = "bytecode-0.16.1.tar.gz", hash = "sha256:8fbbb637c880f339e564858bc6c7984ede67ae97bc71343379a535a9a4baf398"},
+]
+
+[[package]]
 name = "cachelib"
 version = "0.9.0"
 description = "A collection of cache libraries in the same API interface."
@@ -536,6 +548,93 @@ opentelemetry-sdk-extension-aws = ">=2.0.1,<3.0.0"
 requests = ">=2.31.0,<3.0.0"
 
 [[package]]
+name = "ddtrace"
+version = "3.1.0"
+description = "Datadog APM client library"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "ddtrace-3.1.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:88799a0fae7ab7c31285cd8ee4caa2f190bf8daead0ee18adde7ab360a6db816"},
+    {file = "ddtrace-3.1.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:53aa0942ac7360a4706dc108ed6835f99d62ade4efffd5c57b3ea4fd7887b80a"},
+    {file = "ddtrace-3.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a664fe5bdd4c1e7c02128da79a5f2e64c9f6ebc36ed80acf15929a53f6ab979d"},
+    {file = "ddtrace-3.1.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bc49dd2249455032591f8b7dd1e8f102b3290abe7579f3f49832bc8f163c65d8"},
+    {file = "ddtrace-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98b08500fb32f48816488ed841c99394ec42d67a83aad8a83339ac223bc8067a"},
+    {file = "ddtrace-3.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0a1b1aec6927259c190ed03fad71a429e69434a26cfa18e6d4d6f722abf56d99"},
+    {file = "ddtrace-3.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:6cb7ac4df4fe73f770598763687a82f0e5d3bdb4e79f887c91969117dfdae387"},
+    {file = "ddtrace-3.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b5e2fb255cf28dcd4dd675f753f184b19ba6f8362b2fcc920e407910c0721a6d"},
+    {file = "ddtrace-3.1.0-cp310-cp310-win32.whl", hash = "sha256:58bc6e82b2fc773bbb9a893143237666ef68c3af9681014fc51110214906582b"},
+    {file = "ddtrace-3.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:7e3cd3d90c38519353657e0fc36694edfa4a27430e2ca22211cc61199434101b"},
+    {file = "ddtrace-3.1.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:3727f42238f1f1456afa976c36b0bd924fa39199c7c23d7f6c4348aeea207e5d"},
+    {file = "ddtrace-3.1.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:30bd74e0051246b365c8e66c6219e2fc3977852957b83295dfc634273d72ee23"},
+    {file = "ddtrace-3.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d605f00d4b8e4c91a8da070642612de99eb65c3eb844edada524b1c65139582"},
+    {file = "ddtrace-3.1.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:13300759f97dd61acfebe2f414494cb6de78d03854ac57e6b5a52df6717359bf"},
+    {file = "ddtrace-3.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdb57b67793e8a50a9780c1623132aea5573ee2ea1917b4ff59c11f6cec84230"},
+    {file = "ddtrace-3.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:18747ce2ade073616cdfbb07faa62fcde6c638347893956e89124ae565da4bf5"},
+    {file = "ddtrace-3.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:04337b902065856afdb22b31af1c554dda947272f6654d56a06f4c417bbb554a"},
+    {file = "ddtrace-3.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2cf29fe02072a1dd1ba6160d63aa18285cfdeed94d3e9570b5d64c6398290f3f"},
+    {file = "ddtrace-3.1.0-cp311-cp311-win32.whl", hash = "sha256:b75b4ee3064cad14d339c01d5fa9b46d4242f8696f5f3a4b40ef727da9c38694"},
+    {file = "ddtrace-3.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:a0f0fe4b31b94166c04a86b06e8a4ebbed696a10957b05162f3143b9d609859e"},
+    {file = "ddtrace-3.1.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:44733bee07cfb7a04a76b52c030814977f785b593979d0ba86c6a12649fc4b1b"},
+    {file = "ddtrace-3.1.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:3d16343494e0bb99c47c28241bb9598a6eede664ac1811046fafadd02ef537c7"},
+    {file = "ddtrace-3.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f34e6decd8d59b34965392361b8d374c70fb3600e3cb4cd8572faae7a004ff8e"},
+    {file = "ddtrace-3.1.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a6ec895752a720dddaf8d4e89b4dbc1dcc616bb12be81be21ea2b07e709b1c98"},
+    {file = "ddtrace-3.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d0973bdc1ee7fc8091cc59228b24d5378a9b005582a0d06dac0fd771efd3438"},
+    {file = "ddtrace-3.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cd1697747136afb8b48d31044e6a234b446897ca627106ad6f9b7c127a17b112"},
+    {file = "ddtrace-3.1.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:540cbcae29795e3b5ccb6b6122e0854b3d60957bddba6b5ed5455afde022c3ba"},
+    {file = "ddtrace-3.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:92a602e84e477eaf6b09c39ff3f859e62db91f8c25a13cc0edd7e13b49444c55"},
+    {file = "ddtrace-3.1.0-cp312-cp312-win32.whl", hash = "sha256:484893f0946a42792be3bcb95440fab593a3ace7bd81d4e71d6484bf71064920"},
+    {file = "ddtrace-3.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6372da2929444d382df7334293600702fd98873fe941b678b90e82376bc9b7c4"},
+    {file = "ddtrace-3.1.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:760928273afe77e0706c9ec74e98e47c49e3643f133e2e36e626224a244d7a2b"},
+    {file = "ddtrace-3.1.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:41de7c401a937c4cc33e606141224b1842222bb0226f766812e58273ab0d9ff2"},
+    {file = "ddtrace-3.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:620e2ffbb19302516f5b58ad06d4c0fce3d6b5ee571c80e923c35b84fa435a8c"},
+    {file = "ddtrace-3.1.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a3bdd71c3070e4678e188d8418bd36230117bc45b36a092e56247a2383f5ca0a"},
+    {file = "ddtrace-3.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c2d8663074c7896ee0a0dcdc84c33c27e1aee5964318be242cdc3aa3b09da0a"},
+    {file = "ddtrace-3.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76df8adcf5ccd761c1176b273c0dd92ca5e5cce001d56ecd508703c313f3625c"},
+    {file = "ddtrace-3.1.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:866814e8e255c416b819d0c602f2e88c22c92f2d71bc11437583c216038ae939"},
+    {file = "ddtrace-3.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d3776247c7b9837e242edd6809aaac9e46f46abe6d92625854af9a87945d9e8"},
+    {file = "ddtrace-3.1.0-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:14c0fce5505fecf2b4ac238165707945dc736c15696e132ad3efde8d265e8f4c"},
+    {file = "ddtrace-3.1.0-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:8b409ad78708a8265c9c724e8420a1200eb58aa10fd9b00d725e2497747961e5"},
+    {file = "ddtrace-3.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6939817ae5fb371e18ce38933b284206e2950a78c22d9c23feadcdfed92f08d1"},
+    {file = "ddtrace-3.1.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9074d3930ccabc943c3122ef3d6c73db267e8952222749de95de9956d11dfba6"},
+    {file = "ddtrace-3.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4f4d7c050226b54c77bb68e30a0967605afb4eef40cec1281cb3a17ac977918"},
+    {file = "ddtrace-3.1.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:33f4008dec94ba9c7e6f4115b740ed8c8ecdc466c59305567743ba60763cdf29"},
+    {file = "ddtrace-3.1.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:e75990199d927672241194de2c0c2acfe7f8630a4cba24a07e22515d40188258"},
+    {file = "ddtrace-3.1.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:a0d5a49dc3deac3453433c4e5a1e1d804a211973bd653f096d15a4ae356cf883"},
+    {file = "ddtrace-3.1.0-cp38-cp38-win32.whl", hash = "sha256:be7b75a66d8a1283597a12171f3cd611f8fcb0fb2b833e5ed0279dee96a11114"},
+    {file = "ddtrace-3.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:d31a44f296ccb808fdd820157dccb1d49edd302c3ea1854650a58aacaa0e422a"},
+    {file = "ddtrace-3.1.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8d2e81caecefb89d4d0b76f394d887c33c1e645fd290db08448d3d24a53b2cfb"},
+    {file = "ddtrace-3.1.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:ab4161a165bfaddda80527a3fa17458a16e6c63a83ae929498144b0b7430a382"},
+    {file = "ddtrace-3.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:950fa8579cf90b9cf73648199369682989c5b41fc8c85b2d4fb58b6c51554925"},
+    {file = "ddtrace-3.1.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a2ded03e51ef5fa443d9d9afe8ff6fb03c94afada227be149dbd25fa14710aa"},
+    {file = "ddtrace-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a5d90e39f56af1b046b411f51b1e46f2bc74ab39e390d6f9aa516017b37e80b"},
+    {file = "ddtrace-3.1.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:458e448c69b8b0efa929b624e31f655d81ce76b74663142167059b33d7de8052"},
+    {file = "ddtrace-3.1.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cb25bd9adfc24d386566834912f6dda48e0e0f542e8be8483ed611e74ee86ab"},
+    {file = "ddtrace-3.1.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:335d48025f83f072f49e5d969e37d37996c3d43ab0995f91bbf50d851fd87834"},
+    {file = "ddtrace-3.1.0-cp39-cp39-win32.whl", hash = "sha256:41abafbd2cf5a861b74ec487de142da0ad0323a1968233f1b22cdb60f255e205"},
+    {file = "ddtrace-3.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:bf0cd6c7eefd45aa60da2a2b4cd9fe068d68d4bafa44c3efd81abced2a9aac0d"},
+    {file = "ddtrace-3.1.0.tar.gz", hash = "sha256:e8ade97d9c9e37015d3913cb0f1c86483c838a7bc87b036a7936f0930dafe689"},
+]
+
+[package.dependencies]
+bytecode = [
+    {version = ">=0.16.0", markers = "python_version >= \"3.13.0\""},
+    {version = ">=0.15.1", markers = "python_version ~= \"3.12.0\""},
+    {version = ">=0.14.0", markers = "python_version ~= \"3.11.0\""},
+]
+envier = ">=0.5,<1.0"
+legacy-cgi = {version = ">=2.0.0", markers = "python_version >= \"3.13.0\""}
+opentelemetry-api = ">=1"
+protobuf = ">=3"
+typing_extensions = "*"
+wrapt = ">=1"
+xmltodict = ">=0.12"
+
+[package.extras]
+openai = ["tiktoken"]
+opentracing = ["opentracing (>=2.0.0)"]
+
+[[package]]
 name = "decorator"
 version = "5.1.1"
 description = "Decorators for Humans"
@@ -592,6 +691,21 @@ files = [
     {file = "distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87"},
     {file = "distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"},
 ]
+
+[[package]]
+name = "envier"
+version = "0.6.1"
+description = "Python application configuration via the environment"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "envier-0.6.1-py3-none-any.whl", hash = "sha256:73609040a76be48bbcb97074d9969666484aa0de706183a6e9ef773156a8a6a9"},
+    {file = "envier-0.6.1.tar.gz", hash = "sha256:3309a01bb3d8850c9e7a31a5166d5a836846db2faecb79b9cb32654dd50ca9f9"},
+]
+
+[package.extras]
+mypy = ["mypy"]
 
 [[package]]
 name = "executing"
@@ -1104,6 +1218,19 @@ sqlalchemy = ["sqlalchemy (>=1.4.48,<2.1)"]
 sqs = ["boto3 (>=1.26.143)", "pycurl (>=7.43.0.5) ; sys_platform != \"win32\" and platform_python_implementation == \"CPython\"", "urllib3 (>=1.26.16)"]
 yaml = ["PyYAML (>=3.10)"]
 zookeeper = ["kazoo (>=2.8.0)"]
+
+[[package]]
+name = "legacy-cgi"
+version = "2.6.2"
+description = "Fork of the standard library cgi and cgitb modules, being deprecated in PEP-594"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "python_version >= \"3.13.0\""
+files = [
+    {file = "legacy_cgi-2.6.2-py3-none-any.whl", hash = "sha256:a7b83afb1baf6ebeb56522537c5943ef9813cf933f6715e88a803f7edbce0bff"},
+    {file = "legacy_cgi-2.6.2.tar.gz", hash = "sha256:9952471ceb304043b104c22d00b4f333cac27a6abe446d8a528fc437cf13c85f"},
+]
 
 [[package]]
 name = "markupsafe"
@@ -2174,6 +2301,18 @@ files = [
     {file = "wrapt-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35"},
     {file = "wrapt-1.16.0-py3-none-any.whl", hash = "sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1"},
     {file = "wrapt-1.16.0.tar.gz", hash = "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d"},
+]
+
+[[package]]
+name = "xmltodict"
+version = "0.14.2"
+description = "Makes working with XML feel like you are working with JSON"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "xmltodict-0.14.2-py2.py3-none-any.whl", hash = "sha256:20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac"},
+    {file = "xmltodict-0.14.2.tar.gz", hash = "sha256:201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ flask-caching = "^2.1.0"
 dbt-copilot-python = "^0.2.0"
 sentry-sdk = {extras = ["flask"], version = "^2.8.0"}
 gevent = "^24.2.1"
+ddtrace = "^3.1.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.5.0"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,6 @@ import uuid
 from datetime import datetime
 from unittest.mock import patch, MagicMock
 
-import ddtrace
 import urllib3
 from flask import Flask
 from flask import Response
@@ -2301,6 +2300,9 @@ class LoggingTestCase(unittest.TestCase):
         os.environ["DD_ENV"] = "test"
         os.environ["DD_SERVICE"] = "ip-filter"
         os.environ["DD_VERSION"] = "1.0.0"
+        os.environ["ECS_CONTAINER_METADATA_URI"] = (
+            "http://169.254.170.2/v3/709d1c10779d47b2a84db9eef2ebd041-0265927825"
+        )
 
     def test_asim_formatter_get_log_dict(self):
         formatter = ASIMFormatter()
@@ -2381,6 +2383,11 @@ class LoggingTestCase(unittest.TestCase):
             "HttpStatusCode": response.status_code,
         }
 
+    def test_asim_formatter_get_container_id(self):
+        container_id = ASIMFormatter()._get_container_id()
+
+        assert container_id == "709d1c10779d47b2a84db9eef2ebd041-0265927825"
+
     @patch("ddtrace.tracer.current_span")
     def test_asim_formatter_format(self, mock_ddtrace_span):
         mock_ddtrace_span_response = MagicMock()
@@ -2450,6 +2457,7 @@ class LoggingTestCase(unittest.TestCase):
                     "env": "",
                     "service": "",
                     "version": "",
+                    "container_id": "709d1c10779d47b2a84db9eef2ebd041-0265927825",
                 }
             )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2405,6 +2405,19 @@ class LoggingTestCase(unittest.TestCase):
             "dd.span_id": "12448338029536640280",
         }
 
+    @patch("ddtrace.trace.tracer.current_span")
+    def test_get_first_64_bits_of(self, mock_ddtrace_span):
+        trace_id = 5735492756521486600
+
+        mock_ddtrace_span_response = MagicMock()
+        mock_ddtrace_span_response.trace_id = trace_id
+        mock_ddtrace_span_response.span_id = 12448338029536640280
+        mock_ddtrace_span.return_value = mock_ddtrace_span_response
+
+        result = ASIMFormatter()._get_first_64_bits_of(trace_id)
+
+        assert result == str(trace_id)
+
     def test_asim_formatter_get_container_id(self):
         result = ASIMFormatter()._get_container_id()
 


### PR DESCRIPTION
The values being added are `env`, `service`, and `version` which are derived from the `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` environment variables respectively, `dd.trace_id` and `dd.span_id` have also been added. In order to properly test this fucntionality, the environment variables need to be set and the `ddtrace` library reloaded in `LoggingTestCase.setUpClass` since the variables are evaluated in to the `ddtrace.config` object at import time.

Additionally, the `container_id` field has been added to enable logs correlation to container instances within DataDog.

The added fucntionality has been tested, and existing tests are still passing.

<https://uktrade.atlassian.net/browse/DBTP-1662>