### PR TITLE
fix: IP-filter unable to build in CI (DBTP-1662)

### DIFF
--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install poetry
-          poetry install
+          poetry install --no-root
 
       - name: Run pytest
         run: poetry run pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Speak to SRE to get the ip-filter Sentry DSN.
 2. Install the required dependencies:
 
    ```shell
-   pip install poetry && poetry install && poetry run pre-commit install
+   pip install poetry && poetry install --no-root && poetry run pre-commit install
    ```
 
 ### Testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ version = "2.1.0"
 description = ""
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 readme = "README.md"
-package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
The following PR, <https://github.com/uktrade/ip-filter/pull/60>, introduced the `package-mode = false` config to the `pyproject.toml` to fix an issue where installing test dependencies would fail locally. This causes the image build to fail with following error, both locally and in CI.

```
[builder]       The Poetry configuration is invalid:
[builder]         - Additional properties are not allowed ('package-mode' was unexpected)
```

This change removes the added config item, and instead updates the documentation to install the dependencies using the `--no-root` flag.

This issue is caused by using a more recent version of Poetry (`> 2.0.0`) locally but `ci-image-builder` using `1.4.2`.

Addresses <https://uktrade.atlassian.net/browse/DBTP-1662>.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [x] Includes any applicable changes to the documentation in this code base
- [x] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
