### PR TITLE
fix: Add changelog for Gunicorn update (off-ticket)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.1.2](https://github.com/uktrade/ip-filter/compare/2.1.2...2.1.1) (2025-03-26)
+
+
+### Dependencies
+
+* Bump gunicorn from 22.0.0 to 23.0.0 ([#71](https://github.com/uktrade/ip-filter/issues/71)) ([a39bb3e](https://github.com/uktrade/ip-filter/commit/a39bb3e1fa5a180eb0e02a1b0a089cc65399b366))
+
 ## [2.1.1](https://github.com/uktrade/ip-filter/compare/2.1.0...2.1.1) (2025-03-19)
 
 


### PR DESCRIPTION
Trying to release the gunicorn update which was a [high severity vulnerability](https://github.com/uktrade/ip-filter/security/dependabot/36).

I have tested the change in my `demodjango` environment.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- ~[ ] Link to ticket included (unless it's a quick out of ticket thing)~
- ~[ ] Includes tests (or an explanation for why it doesn't)~
- ~[ ] Includes any applicable changes to the documentation in this code base~
- ~[ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~
